### PR TITLE
🐛 Ensure base path includes trailing slash

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import mdx from '@astrojs/mdx';
 // https://astro.build/config
 export default defineConfig({
   site: 'https://nexusdatalabs.github.io/',
-  base: '/filecoin-watch',
+  base: '/filecoin-watch/',
   experimental: {
     fonts: [
       {


### PR DESCRIPTION
## Summary
- add trailing slash to `base` in Astro config

## Testing
- `npx astro check`
- `npm run build` *(fails: Could not establish connection error for HTTP HEAD to 'https://data.filecoindataportal.xyz/filecoin_daily_metrics.parquet')*

------
https://chatgpt.com/codex/tasks/task_e_68b824a9b7f4832e9e63cb69fb2f8d18