### PR TITLE
🐛 Fix script tag and unify hover background

### DIFF
--- a/src/components/ClientsTable.astro
+++ b/src/components/ClientsTable.astro
@@ -61,7 +61,7 @@ const cid = `ctbl-${Math.random().toString(36).slice(2, 8)}`;
     type="application/json"
     data-source
     set:html={JSON.stringify(rows)}
-  />
+  ></script>
 </section>
 
 <script is:inline define:vars={{ cid }}>
@@ -321,7 +321,7 @@ const cid = `ctbl-${Math.random().toString(36).slice(2, 8)}`;
     cursor: not-allowed;
   }
   .pager button:hover:not(:disabled) {
-    background: #f2f2f2;
+    background: var(--hover-bg);
   }
   .pager button:focus-visible {
     outline: 2px solid currentColor;

--- a/src/components/DateFilter.astro
+++ b/src/components/DateFilter.astro
@@ -155,7 +155,7 @@
     border-radius: 6px;
   }
   .date-filter button:hover {
-    background: #f2f2f2;
+    background: var(--hover-bg);
   }
   .date-filter button:focus-visible {
     outline: 2px solid currentColor;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -66,7 +66,7 @@ const baseUrl = import.meta.env.BASE_URL;
   }
 
   a.cta:hover {
-    background: #f2f2f2;
+    background: var(--hover-bg);
   }
 
   a.cta:focus-visible {

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,6 +16,7 @@
     --fg: #111;
     --muted: #666;
     --border: #e5e5e5;
+    --hover-bg: #f2f2f2;
     --code-bg: #f6f8fa;
     --blockquote-bg: #fafafa;
     --link-underline: #b1b1b1;
@@ -340,7 +341,7 @@ pre:focus-within .copy-btn {
 }
 
 .copy-btn:hover {
-    background: #f2f2f2;
+    background: var(--hover-bg);
 }
 
 .copy-btn:focus-visible {


### PR DESCRIPTION
## Summary
- fix ClientsTable JSON script tag
- centralize hover background using CSS variable

## Testing
- `npx astro check` *(fails: Cannot find module '../../data/clients.json')*
- `npm run build` *(fails: duckdb: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c044128d60832ebf8aec8d3d138341